### PR TITLE
strip whitespace between permission urls

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -113,7 +113,7 @@ $(function(){
 			}else if ($(this).is(':checked')){
 				modules.push($(this).val());
 			}else if($(this).is('.match_pattern') && $(this).val() !=''){
-				match_ptrns = $(this).val().split(';');
+				match_ptrns = $(this).val().replace(/\s+|\s+$/g, '').split(';');
 			}
 		});
 		permissions = boolean_perms.concat(match_ptrns);


### PR DESCRIPTION
Quick fix for eliminating all white spaces in the permission urls, which can get ugly is not inserted correctly.
