### PR TITLE
Download from blob url instead of data url

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -389,12 +389,12 @@ $(function(){
 			//write new manifest to filesystem API
 			extFs.addText('manifest.json', manifestJson);
 			genButton.html('Generating download!').addClass('loading');
-			zipFs.exportData64URI(function (data) {
+			zipFs.exportBlob(function (data) {
 				genButton.html('Download ready!').removeClass('loading');
 
 				var clickEvent = document.createEvent("MouseEvent");
 				clickEvent.initMouseEvent("click", true, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
-				downloadButton.href = data;
+				downloadButton.href = (window.URL || window.webkitURL).createObjectURL(data);
 				_gaq.push(['_trackEvent', 'Buttons', "download-button"]);
 				downloadButton.download = 'extensionizr_custom' + Date.now() + '.zip';
 				downloadButton.dispatchEvent(clickEvent);


### PR DESCRIPTION
a[download] no longer works with data url in Chrome. It downloads the zip as "download.zip".

More info here:
https://code.google.com/p/chromium/issues/detail?id=375634#c2

Tests:
http://web-tests.webatu.com/extensionizr-data/ (old)
http://web-tests.webatu.com/extensionizr-blob/ (new)
