### PR TITLE
Use match_patterns page for url permissions

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,7 +162,7 @@
 					</div>
 					<div class="customize-section special-section">
 						<h3>URL permissions
-							<a class="more_info" target="_blank" href="http://developer.chrome.com/extensions/manifest.html#permissions" data-content="Url permissions are a match pattern set that gives your extension access to one or more hosts."></a>
+							<a class="more_info" target="_blank" href="http://developer.chrome.com/extensions/match_patterns" data-content="Url permissions are a match pattern set that gives your extension access to one or more hosts."></a>
 						</h3>
 						<!--<label><input type="checkbox" name="match-pattern" value="match-pattern" id="match-pattern"> Match pattern: </label>-->
 						<input id="match_ptrns" type="text" class="match_pattern" name="uri-perms" value=""> <span>Separated by ";" (https://*/* ; http://google.com/*)</span>


### PR DESCRIPTION
I was a bit confused about match patterns for url permissions when using Extensionzir, especially since http://developer.chrome.com/extensions/manifest.html#permissions no longer displays the relevant info.  http://developer.chrome.com/extensions/match_patterns seems to be the updated page!

Great project by the way :)